### PR TITLE
Remove dir properly

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,7 @@ import {
 import { Settings, DEFAULT_SETTINGS, settingsToMap } from "settings/settings";
 import { ParaShortcutsSettingTab } from "settings/settings_tab";
 import { CreateNewEntryModal } from "modals/new_entry_modal";
-import { isParaType, ParaType } from "para_types";
+import { ParaType } from "para_types";
 
 const DATE_FORMAT = "YYYY-MM-DD";
 const POSTPONE_FOLDER_NAME = "postponed";

--- a/src/para_types.ts
+++ b/src/para_types.ts
@@ -1,15 +1,6 @@
-export enum ParaType{
+export enum ParaType {
 	projects = "Projects", 
 	areas_of_responsibility = "Areas of Responsibility", 
 	resources = "Resources",
 	archive = "Archive"
-}
-
-export function isParaType(s: String): boolean{
-	for (const val in ParaType){
-		if (val === s){
-			return true;
-		}
-	}
-	return false;
 }


### PR DESCRIPTION
It turned out that I broke archive directory removal a bit. When `deleteFolderIfEmpty` is called, file is already moved, so we're trying to remove destination folder. Fortunately, it's not empty, so nothing destructive happens:

https://github.com/gOATiful/para-shortcuts/pull/17/files#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dR151-R155
